### PR TITLE
bug fix names changed by data.frame

### DIFF
--- a/R/plot_pattern.R
+++ b/R/plot_pattern.R
@@ -93,7 +93,8 @@ plot_pattern <-
 
     # tidy the pattern
     long <-
-      data.frame(.y = 1:(rws - 1), pat_clean, row.names = NULL) %>%
+      cbind(.y = 1:(rws - 1), pat_clean) %>%
+      as.data.frame(.) %>%
       tidyr::pivot_longer(
         cols = tidyselect::all_of(vrb),
         names_to = "x",

--- a/tests/testthat/test-plot_pattern.R
+++ b/tests/testthat/test-plot_pattern.R
@@ -3,6 +3,8 @@ test_that("plot_pattern produces plot", {
   expect_s3_class(gg, "ggplot")
   gg <- plot_pattern(mice::nhanes, square = FALSE, rotate = TRUE, cluster = "age", npat = 2)
   expect_s3_class(gg, "ggplot")
+  gg <- plot_pattern(cbind(mice::nhanes, "test var" = NA))
+  expect_s3_class(gg, "ggplot")
 })
 
 test_that("plot_pattern with incorrect argument(s)", {


### PR DESCRIPTION
Previously if variable names were of the form `White Blood Cells` then the function data.frame would change them to "White.Blood.Cells" which would then mean the element "White Blood Cells" in vrb cannot be found in tidyr::pivot_longer which causes the error "Can't subset elements that don't exist"

dummy example:

x = tibble(`Variable One` = sample(c(1,NA_real_),100,replace = TRUE),
                 `Variable Two` = sample(c(2,NA_real_),100,replace = TRUE),
                 var3 = sample(c(3,NA_real_),100,replace = TRUE))
ggmice::plot_pattern(x)
